### PR TITLE
大佬，发现您的项目引入了org.apache.ant:ant@1.10.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache</groupId>
     <artifactId>tomcat</artifactId>
@@ -51,7 +50,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.9</version>
         </dependency>
         <dependency>
             <groupId>wsdl4j</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Ant信息泄露漏洞
缺陷组件：org.apache.ant:ant@1.10.0
漏洞编号：CVE-2020-1945
漏洞描述：Apache Ant是美国阿帕奇软件（Apache Software）基金会的一套用于Java软件开发的自动化工具。该工具主要用于软件的编译、测试和部署等。
Apache Ant 1.1版本至1.9.14版本和1.10.0版本至1.10.7版本中存在安全漏洞。攻击者可利用该漏洞泄漏敏感信息。 
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2020-46282
影响范围：[1.10.0, 1.10.8)
最小修复版本：1.10.9
缺陷组件引入路径：org.apache:tomcat@8.5.72->org.apache.ant:ant@1.10.0
```
另外我运行这个项目时，IDE的安全插件提示还有1个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p41ada